### PR TITLE
Let examples build from open62541 binaries that are not installed

### DIFF
--- a/examples/examples_common.cmake
+++ b/examples/examples_common.cmake
@@ -11,11 +11,14 @@ include(../../Common.cmake)
 include_directories( ../../include )
 
 # Add Open62541 libraries
-find_library(OPEN62541 Open62541Cpp ${CMAKE_INSTALL_PREFIX}/lib)
 add_executable(${APPNAME} ${SOURCES})
-target_link_libraries (${APPNAME} ${OPEN62541})
+target_link_libraries (${APPNAME} open62541cpp)
 
 # add boost to target
 if(Boost_FOUND)
     target_link_libraries(${APPNAME} ${Boost_LIBRARIES})
 endif()
+
+install(TARGETS ${APPNAME}
+        RUNTIME DESTINATION bin
+        )


### PR DESCRIPTION
This lets cmake build everything in one go without having to install open62541cpp to the machine

I also added an install target to the examples