### PR TITLE
fix: correctly set UA_AccessControl_default

### DIFF
--- a/include/open62541cpp/open62541server.h
+++ b/include/open62541cpp/open62541server.h
@@ -504,7 +504,7 @@ public:
     {
         ByteString ut(userTokenPolicyUri);
         // install access control into the config that maps on to the server hence its virtual functions
-        UA_AccessControl_default(_config, allowAnonymous, nullptr,
+        UA_AccessControl_default(_config, allowAnonymous,
                                   &_config->securityPolicies[_config->securityPoliciesSize-1].policyUri,
                                  _logins.size(), _logins.data());
         setAccessControl(&_config->accessControl);  // map access control requests to this object


### PR DESCRIPTION
The nullptr is wrong. 

Syntax is:

```cpp
UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
                         const UA_ByteString *userTokenPolicyUri,
                         size_t usernamePasswordLoginSize,
                         const UA_UsernamePasswordLogin *usernamePasswordLogin);
```